### PR TITLE
JM - Commit Tracking Infrastructure Setup: Dockerfile, SystemInfo, pom.xml - [Backend]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add curl
 RUN apk add bash
 RUN apk add maven
 RUN apk add --no-cache libstdc++
+RUN apk add git
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
@@ -15,13 +16,11 @@ RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
 RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-RUN node --version
-RUN npm --version
+# By copying the entire directory (including git info),
+# much of the configuration relies on the dokku setting:
+#   dokku git:set appname keep-git-dir true
 
-COPY frontend /home/app/frontend
-COPY src /home/app/src
-COPY lombok.config /home/app
-COPY pom.xml /home/app
+COPY . /home/app
 
 ENV PRODUCTION=true
 RUN mvn -B -DskipTests -Pproduction -f /home/app/pom.xml clean package

--- a/pom.xml
+++ b/pom.xml
@@ -476,6 +476,25 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>io.github.git-commit-id</groupId>
+                        <artifactId>git-commit-id-maven-plugin</artifactId>
+                        <version>8.0.2</version>
+                        <executions>
+                            <execution>
+                                <id>get-the-git-infos</id>
+                                <goals>
+                                    <goal>revision</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                            <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                            <commitIdGenerationMode>full</commitIdGenerationMode>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/SystemInfo.java
@@ -13,6 +13,11 @@ import lombok.AccessLevel;
 public class SystemInfo {
   private Boolean springH2ConsoleEnabled;
   private Boolean showSwaggerUILink;
-  private String sourceRepo;
+  private String startQtrYYYYQ;
+  private String endQtrYYYYQ;
+  private String sourceRepo; // user configured URL of the source repository
+  private String commitMessage;
+  private String commitId;
+  private String githubUrl; // URL to the commit in the source repository
   private String oauthLogin;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
@@ -22,8 +22,24 @@ public class SystemInfoServiceImpl extends SystemInfoService {
   @Value("${app.showSwaggerUILink:false}")
   private boolean showSwaggerUILink;
 
+  @Value("${app.startQtrYYYYQ:20221}")
+  private String startQtrYYYYQ;
+
+  @Value("${app.endQtrYYYYQ:20243}")
+  private String endQtrYYYYQ;
+
   @Value("${app.sourceRepo}")
   private String sourceRepo = "https://github.com/ucsb-cs156/proj-happycows";
+
+  @Value("${git.commit.message.short:unknown}")
+  private String commitMessage;
+
+  @Value("${git.commit.id.abbrev:unknown}")
+  private String commitId;
+
+  public static String githubUrl(String repo, String commit) {
+    return commit != null && repo != null ? repo + "/commit/" + commit : null;
+  }
 
   @Value("${app.oauth.login:/oauth2/authorization/google}")
   private String oauthLogin;
@@ -32,7 +48,12 @@ public class SystemInfoServiceImpl extends SystemInfoService {
     SystemInfo si = SystemInfo.builder()
     .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
     .showSwaggerUILink(this.showSwaggerUILink)
+    .startQtrYYYYQ(this.startQtrYYYYQ)
+    .endQtrYYYYQ(this.endQtrYYYYQ)
     .sourceRepo(this.sourceRepo)
+    .commitMessage(this.commitMessage)
+    .commitId(this.commitId)
+    .githubUrl(githubUrl(this.sourceRepo, this.commitId))
     .oauthLogin(this.oauthLogin)
     .build();
   log.info("getSystemInfo returns {}",si);

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.happiercows.services;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +30,16 @@ class SystemInfoServiceImplTests  {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
     assertTrue(si.getShowSwaggerUILink());
-    assertEquals("https://github.com/ucsb-cs156/proj-happycows", si.getSourceRepo());
+    assertTrue(si.getGithubUrl().startsWith(si.getSourceRepo()));
+    assertTrue(si.getGithubUrl().endsWith(si.getCommitId()));
+    assertTrue(si.getGithubUrl().contains("/commit/"));
   }
 
+  @Test
+  void test_githubUrl() {
+    assertEquals(SystemInfoServiceImpl.githubUrl("https://github.com/ucsb-cs156/proj-happycows", "abcdef12345"), "https://github.com/ucsb-cs156/proj-happycows/commit/abcdef12345");
+    assertNull(SystemInfoServiceImpl.githubUrl(null, null));
+    assertNull(SystemInfoServiceImpl.githubUrl("x", null));
+    assertNull(SystemInfoServiceImpl.githubUrl(null, "x"));
+  }
 }


### PR DESCRIPTION
## Overview
Hello everybody! I've currently set up the infrastructure foundation for issue #7 . I'm planning on splitting up issue #7 into multiple issues -- this one deals with issue #15.  Changes include altering the Dockerfile to work with the `git-commit-id-maven-plugin` properly, altering the `pom.xml` file to include the `git-commit-id-maven-plugin,` and setting up the fields in the `SystemInfo.java` files to track the information we want.

This pull request will be the first of a couple within the same issue. Now that the plugin is set up and that the foundations are there, next step is to investigate how to properly propagate the values with information other than the default values.

## Screenshots (Optional)
<img width="665" alt="image" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/61306390/84d29393-cc62-45b2-badb-5c3705060476">

Link to my Dokku Deployment where the `/api/systeminfo` endpoint is set up properly.
https://[proj-happycows-jm.dokku-08.cs.ucsb.edu/api/systemInfo](https://proj-happycows-jm.dokku-08.cs.ucsb.edu/api/systemInfo)


## Tests
<!--Add any additional tests or required tests-->
- [X] Backend Unit tests (`mvn test`) pass
- [X] Backend Test coverage (`mvn test jacoco:report`) 100%
- [X] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues

Parent issue: #7 
Closes #15 
