### PR TITLE
JM - Commit Tracking Through the SystemInfo API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,31 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
 
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>8.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.message.short$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
+            </plugin>
+
             <!-- Test case coverage report -->
             <plugin>
                 <groupId>org.jacoco</groupId>
@@ -475,25 +500,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>io.github.git-commit-id</groupId>
-                        <artifactId>git-commit-id-maven-plugin</artifactId>
-                        <version>8.0.2</version>
-                        <executions>
-                            <execution>
-                                <id>get-the-git-infos</id>
-                                <goals>
-                                    <goal>revision</goal>
-                                </goals>
-                                <phase>initialize</phase>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-                            <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
-                            <commitIdGenerationMode>full</commitIdGenerationMode>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImpl.java
@@ -4,6 +4,8 @@ package edu.ucsb.cs156.happiercows.services;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.happiercows.models.SystemInfo;
@@ -14,6 +16,9 @@ import edu.ucsb.cs156.happiercows.models.SystemInfo;
 @Slf4j
 @Service("systemInfo")
 @ConfigurationProperties
+@PropertySources(
+  @PropertySource("classpath:git.properties")
+)
 public class SystemInfoServiceImpl extends SystemInfoService {
   
   @Value("${spring.h2.console.enabled:false}")


### PR DESCRIPTION
## Overview
Hi everyone! This PR addresses issue #7 and builds upon issue #15 . Issue #15 set up the necessary deployment infrastructure to support the GitHub commit-tracking plugin, and this PR officially uses the plugin to display the information on the `/api/systemInfo` endpoint.

Note: This PR also involves the relocation of the `<plugin>...</plugin>` code to be moved from just PRODUCTION build to the general build (applicable to all types of build). This code was mistakenly placed in the PRODUCTION build in the last PR, and this PR fixes that.

## Screenshots (Optional)
<img width="676" alt="image" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/61306390/d2cf83aa-f162-4aff-817b-2d35871d216f">

Link to my Dokku Deployment where the `/api/systemInfo` endpoint is set up properly, and displays the correct commit tracking information:
https://[proj-happycows-jm.dokku-08.cs.ucsb.edu/api/systemInfo](https://proj-happycows-jm.dokku-08.cs.ucsb.edu/api/systemInfo)

## Future Possibilities (Optional)
One thing I noticed is that the Fixtures / Frontend stuff for the `/api/systemInfo` information is outdated. Perhaps a future issue / PR could overhaul the outdated frontend informatino to now include the relevant commit plugin.

## Tests
<!--Add any additional tests or required tests-->
- [X] Backend Unit tests (`mvn test`) pass
- [X] Backend Test coverage (`mvn test jacoco:report`) 100%
- [X] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
 
## Linked Issues
Closes #7 
