### PR TITLE
JM - Added Suspended field to User

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -26,6 +26,7 @@ public class User {
     private String locale;
     private String hostedDomain;
     private boolean admin;
+    private boolean suspended;
 
   @Builder.Default
   private Instant lastOnline = Instant.now();

--- a/src/main/resources/db/migration/changes/User_Suspended_Field.json
+++ b/src/main/resources/db/migration/changes/User_Suspended_Field.json
@@ -1,0 +1,41 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "User-Suspended-Field",
+        "author": "JeffreyM",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "columnExists": {
+                  "tableName": "USERS",
+                  "columnName": "SUSPENDED"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "addColumn": {
+              "tableName": "USERS",
+              "columns": [
+                {
+                  "column": {
+                    "name": "SUSPENDED",
+                    "type": "BOOLEAN",
+                    "defaultValue": "false"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Overview
Hi everyone! This PR is a simple database migration and change to the `User.java` entity file which adds the `suspended` boolean field. This PR is a subissue #17  which will build up to solving issue #4 .

## Screenshots
H2 Console screenshot:
<img width="1289" alt="image" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/61306390/948ee44b-65b4-4d4f-9e40-dab2466ce3f7">

Dokku deployment still works as expected:
https://proj-happycows-jm.dokku-08.cs.ucsb.edu/

Unfortunately, I cannot show the H2 console on Dokku ^


## Tests
<!--Add any additional tests or required tests-->
- [X] Backend Unit tests (`mvn test`) pass
- [X] Backend Test coverage (`mvn test jacoco:report`) 100%
- [X] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues
<!--Issues related to the PR-->
Closes #17 
