### PR TITLE
JM - Added API Endpoints and Tests for Suspending and Restoring Users

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -42,25 +42,23 @@ public class UsersController extends ApiController {
     @Operation(summary = "Suspend a user by id")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/suspend")
-    public ResponseEntity<String> suspendUser(@Parameter(name="userId") @RequestParam long userId ) throws JsonProcessingException {
+    public Object suspendUser(@Parameter(name="userId") @RequestParam long userId ) throws JsonProcessingException {
 
         User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(User.class, userId));
 
         user.setSuspended(true);
-        User savedUser = userRepository.save(user);
-        String body = mapper.writeValueAsString(savedUser);
-        return ResponseEntity.ok().body(body);
+        userRepository.save(user);
+        return genericMessage("User with id %d suspended".formatted(userId));
     }
 
     @Operation(summary="Restore a user by id")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/restore")
-    public ResponseEntity<String> restoreUser(@Parameter(name="userId") @RequestParam long userId ) throws JsonProcessingException {
+    public Object restoreUser(@Parameter(name="userId") @RequestParam long userId ) throws JsonProcessingException {
         User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(User.class, userId));
 
         user.setSuspended(false);
-        User savedUser = userRepository.save(user);
-        String body = mapper.writeValueAsString(savedUser);
-        return ResponseEntity.ok().body(body);
+        userRepository.save(user);
+        return genericMessage("User with id %d restored".formatted(userId));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -7,13 +7,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 
 @Tag(name="User information (admin only)")
 @RequestMapping("/api/admin/users")
@@ -32,6 +36,31 @@ public class UsersController extends ApiController {
             throws JsonProcessingException {
         Iterable<User> users = userRepository.findAll();
         String body = mapper.writeValueAsString(users);
+        return ResponseEntity.ok().body(body);
+    }
+    
+    @Operation(summary = "Suspend a user by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/suspend")
+    public ResponseEntity<String> suspendUser(@Parameter(name="userId") @RequestParam long userId ) throws JsonProcessingException {
+
+        User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(User.class, userId));
+
+        user.setSuspended(true);
+        User savedUser = userRepository.save(user);
+        String body = mapper.writeValueAsString(savedUser);
+        return ResponseEntity.ok().body(body);
+    }
+
+    @Operation(summary="Restore a user by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/restore")
+    public ResponseEntity<String> restoreUser(@Parameter(name="userId") @RequestParam long userId ) throws JsonProcessingException {
+        User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException(User.class, userId));
+
+        user.setSuspended(false);
+        User savedUser = userRepository.save(user);
+        String body = mapper.writeValueAsString(savedUser);
         return ResponseEntity.ok().body(body);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
@@ -15,14 +15,19 @@ import edu.ucsb.cs156.happiercows.testconfig.TestConfig;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
@@ -73,5 +78,73 @@ public class UsersControllerTests extends ControllerTestCase {
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
 
+  }
+
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void regular_user_cannot_suspend_user() throws Exception { 
+    mockMvc.perform(post("/api/admin/users/suspend")
+                .param("userId", "1")
+                .with(csrf()))
+                .andExpect(status().isForbidden());
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void regular_user_cannot_restore_user() throws Exception {
+    mockMvc.perform(post("/api/admin/users/restore")
+                .param("userId", "1")
+                .with(csrf()))
+                .andExpect(status().isForbidden());
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_user_can_suspend_user() throws Exception {
+    User u1 = User.builder().id(1L).build();
+    User user = spy(u1);
+    when(userRepository.findById(u1.getId())).thenReturn(Optional.of(user));
+    when(userRepository.save(any(User.class))).thenReturn(user);
+
+    MvcResult response = mockMvc.perform(post("/api/admin/users/suspend").param("userId", "1").with(csrf())).andExpect(status().isOk()).andReturn();
+
+    verify(userRepository, times(1)).save(user);
+    verify(user, times(1)).setSuspended(true);
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("User with id 1 suspended", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_user_can_restore_user() throws Exception {
+    User u1 = User.builder().id(1L).build();
+    User user = spy(u1);
+    when(userRepository.findById(u1.getId())).thenReturn(Optional.of(user));
+    when(userRepository.save(any(User.class))).thenReturn(user);
+
+    MvcResult response = mockMvc.perform(post("/api/admin/users/restore").param("userId", "1").with(csrf())).andExpect(status().isOk()).andReturn();
+
+    verify(userRepository, times(1)).save(user);
+    verify(user, times(1)).setSuspended(false);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("User with id 1 restored", json.get("message"));
+  }
+
+  @WithMockUser(roles={"ADMIN"})
+  @Test
+  public void admin_user_cannot_suspend_invalid_user() throws Exception {
+    when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+    mockMvc.perform(post("/api/admin/users/suspend").param("userId", "1").with(csrf())).andExpect(status().isNotFound());
+  }
+
+  @WithMockUser(roles={"ADMIN"})
+  @Test
+  public void admin_user_cannot_restore_invalid_user() throws Exception {
+    when(userRepository.findById(1L)).thenReturn(Optional.empty());
+
+    mockMvc.perform(post("/api/admin/users/restore").param("userId", "1").with(csrf())).andExpect(status().isNotFound());
   }
 }


### PR DESCRIPTION
## Overview
Hi everyone! This PR creates 2 different API endpoints to both `restore` and `suspend` a user.
* `/api/admin/users/suspend/{user_id}`
* `/api/admin/users/restore/{user_id}`

This PR builds on top of issue #17 to change the suspended field depending on the API endpoint an admin user calls. I've also confirmed 100% mutation and line coverage.

## Screenshots (Optional)
<img width="806" alt="image" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/61306390/bde9f550-7fc7-4726-8d50-3d295497e8c9">

Link to Dokku Swagger UI: https://proj-happycows-jm.dokku-08.cs.ucsb.edu/swagger-ui/index.html#/User%20information%20(admin%20only)/suspendUser

<img width="1378" alt="image" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/61306390/d56cccdb-c747-40f7-956c-c35fe854f36a">

<img width="1362" alt="image" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/61306390/4bec2db4-96c7-4b50-9e4f-dd1e0bee5cfc">

## Tests
<!--Add any additional tests or required tests-->
- [X] Backend Unit tests (`mvn test`) pass
- [X] Backend Test coverage (`mvn test jacoco:report`) 100%
- [X] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues
<!--Issues related to the PR-->
Closes #19 
