### PR TITLE
JM - Added Authorization Gatekeeping for Suspended Users and Automatic Role Interception

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/interceptors/RoleUserInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/interceptors/RoleUserInterceptor.java
@@ -1,0 +1,74 @@
+package edu.ucsb.cs156.happiercows.interceptors;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Optional;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Collection;
+import edu.ucsb.cs156.happiercows.entities.User;
+
+
+
+@Component
+public class RoleUserInterceptor implements HandlerInterceptor {
+
+   @Autowired
+   UserRepository userRepository;
+
+   @Override
+   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // Update user's security context on server each time the user makes HTTP request to the backend
+        // If user has admin status in database we will keep ROLE_ADMIN in security context
+        // Otherwise interceptor will remove ROLE_ADMIN before the incoming request is processed by backend API
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        Authentication authentication = securityContext.getAuthentication();
+
+        if (authentication instanceof OAuth2AuthenticationToken ) {
+            OAuth2User oAuthUser = ((OAuth2AuthenticationToken) authentication).getPrincipal();
+            String email = oAuthUser.getAttribute("email");
+            Optional<User> optionalUser = userRepository.findByEmail(email);
+            if (optionalUser.isPresent()){
+                User user = optionalUser.get();
+
+                if(user.isSuspended()) {
+                    response.sendError(HttpServletResponse.SC_FORBIDDEN, "Your account has been suspended. Contact an administrator to restore your account");
+                    SecurityContextHolder.clearContext();
+                    return false;
+                }
+
+                Set<GrantedAuthority> newAuthorities = new HashSet<>();
+                Collection<? extends GrantedAuthority> currentAuthorities = authentication.getAuthorities();
+                currentAuthorities.stream()
+                .filter(authority -> !authority.getAuthority().equals("ROLE_ADMIN"))
+                .forEach(authority -> {
+                    newAuthorities.add(authority);
+                });
+
+                if (user.isAdmin()){
+                    newAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+                }
+                
+                Authentication newAuth = new OAuth2AuthenticationToken(oAuthUser, newAuthorities,(((OAuth2AuthenticationToken)authentication).getAuthorizedClientRegistrationId()));
+                SecurityContextHolder.getContext().setAuthentication(newAuth);
+            }
+        }
+
+      return true;
+   }
+    
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/interceptors/RoleUserInterceptorAppConfig.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/interceptors/RoleUserInterceptorAppConfig.java
@@ -1,0 +1,19 @@
+package edu.ucsb.cs156.happiercows.interceptors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Component
+public class RoleUserInterceptorAppConfig implements WebMvcConfigurer {
+   @Autowired
+   RoleUserInterceptor roleUserInterceptor;
+
+   @Override
+   public void addInterceptors(InterceptorRegistry registry) {
+      registry.addInterceptor(roleUserInterceptor);
+   }
+
+}
+   

--- a/src/test/java/edu/ucsb/cs156/happiercows/interceptors/RoleUserInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/interceptors/RoleUserInterceptorTests.java
@@ -1,0 +1,178 @@
+package edu.ucsb.cs156.happiercows.interceptors;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
+import wiremock.javax.servlet.http.HttpServletResponse;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class RoleUserInterceptorTests {
+  @MockBean
+  UserRepository userRepository;
+
+  @Autowired
+  private RequestMappingHandlerMapping mapping;
+
+  @BeforeEach
+  public void setupSecurityContext() {
+    // private boolean admin;
+    // private boolean suspended;
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("id", 1);
+    attributes.put("email", "gauchoMock@ucsb.edu");
+    attributes.put("googleSub", "mockGoogleSub");
+    attributes.put("fullName", "Mock Mock");
+    attributes.put("givenName", "Mock Mock");
+    attributes.put("familyName", "Mock Mock");
+    attributes.put("emailVerified", true);
+    attributes.put("locale", "mockLocale");
+    attributes.put("hostedDomain", "mockHostedDomain");
+
+    Set<GrantedAuthority> fakeAuthorities = new HashSet<>();
+    fakeAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+    fakeAuthorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+    OAuth2User mockUser = new DefaultOAuth2User(fakeAuthorities, attributes, "email");
+    Authentication authentication = new OAuth2AuthenticationToken(mockUser, fakeAuthorities, "mockUserRegisterId");
+
+    SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+  }
+
+  @Test
+  public void user_not_present_in_db_and_no_role_update_by_interceptor() throws Exception {
+    when(userRepository.findByEmail("gauchoMock@ucsb.edu")).thenReturn(Optional.empty());
+
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+    HandlerExecutionChain chain = mapping.getHandler(request);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assert chain != null;
+    Optional<HandlerInterceptor> roleRuleInterceptor = chain.getInterceptorList()
+                    .stream()
+                    .filter(RoleUserInterceptor.class::isInstance)
+                    .findAny();
+
+    assertTrue(roleRuleInterceptor.isPresent());
+    roleRuleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+    Collection<? extends GrantedAuthority> updatedAuthorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+    verify(userRepository, times(1)).findByEmail("gauchoMock@ucsb.edu");
+    boolean hasAdminRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
+    boolean hasUserRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_USER"));
+    assertTrue(hasAdminRole, "ROLE_ADMIN should exist authorities");
+    assertTrue(hasUserRole, "ROLE_USER should exist in authorities");
+  }
+
+  @Test
+  public void interceptor_removes_admin_role_when_admin_field_in_db_is_false() throws Exception {
+    User mockUser = User.builder()
+      .id(1)
+      .email("gauchoMock@ucsb.edu")
+      .googleSub("mockGoogleSub")
+      .fullName("Mock Mock")
+      .givenName("Mock Mock")
+      .familyName("Mock Mock")
+      .emailVerified(true)
+      .locale("mockLocale")
+      .hostedDomain("mockHostedDomain")
+      .admin(false)
+      .build();
+    when(userRepository.findByEmail("gauchoMock@ucsb.edu")).thenReturn(Optional.of(mockUser));
+
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+    HandlerExecutionChain chain = mapping.getHandler(request);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assert chain != null;
+    Optional<HandlerInterceptor> roleRuleInterceptor = chain.getInterceptorList()
+                    .stream()
+                    .filter(RoleUserInterceptor.class::isInstance)
+                    .findAny();
+
+    assertTrue(roleRuleInterceptor.isPresent());
+    boolean result = roleRuleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+    Collection<? extends GrantedAuthority> updatedAuthorities = SecurityContextHolder.getContext().getAuthentication().getAuthorities();
+    verify(userRepository, times(1)).findByEmail("gauchoMock@ucsb.edu");
+    boolean hasAdminRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_ADMIN"));
+    boolean hasUserRole = updatedAuthorities.stream().anyMatch(authority -> authority.getAuthority().equals("ROLE_USER"));
+
+    assertFalse(hasAdminRole, "ROLE_ADMIN should exist authorities");
+    assertTrue(hasUserRole, "ROLE_USER should exist in authorities");
+    assertTrue(result);
+  }
+
+
+  @Test
+  public void interceptor_logs_out_user_when_suspended_field_in_db_is_true() throws Exception {
+    User mockUser = User.builder()
+      .id(1)
+      .email("gauchoMock@ucsb.edu")
+      .googleSub("mockGoogleSub")
+      .fullName("Mock Mock")
+      .givenName("Mock Mock")
+      .familyName("Mock Mock")
+      .emailVerified(true)
+      .locale("mockLocale")
+      .hostedDomain("mockHostedDomain")
+      .admin(false)
+      .suspended(true)
+      .build();
+    when(userRepository.findByEmail("gauchoMock@ucsb.edu")).thenReturn(Optional.of(mockUser));
+
+
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+    HandlerExecutionChain chain = mapping.getHandler(request);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    assert chain != null;
+    Optional<HandlerInterceptor> roleRuleInterceptor = chain.getInterceptorList()
+                    .stream()
+                    .filter(RoleUserInterceptor.class::isInstance)
+                    .findAny();
+
+    assertTrue(roleRuleInterceptor.isPresent());
+    boolean result = roleRuleInterceptor.get().preHandle(request, response, chain.getHandler());
+    
+    verify(userRepository, times(1)).findByEmail("gauchoMock@ucsb.edu");
+    assertFalse(result);
+    assertEquals(response.getStatus(), HttpServletResponse.SC_FORBIDDEN);
+    assertNull(SecurityContextHolder.getContext().getAuthentication());
+  }
+}


### PR DESCRIPTION
## Overview
In this PR, I've included 3 different files: `RoleUserInterceptor.java`, `RoleUserInterceptorAppConfig.java`, and `RoleUserInterceptorTests.java` modeled after the role-interceptor functionalities in `proj-organic`. This PR addresses the two subitems listed in issue #22 within the same PR (both part A and part B).

Originally, I had implemented both parts separately by adding an `AuthorizationSuccessHandler` within the `SecurityConfig.java` file, but realized that this created a lot of redundance and impacted files that did not need to be impacted. Including the handler / changing the `SecurityConfig.java` file would also cause a lot of issues if we were to attempt the migration from spring-boot 2 to 3. To prevent the manipulation of unnecessary files, I decided to bundle the Authorization Gatekeeping in `RoleUserInterceptor.java` and remove the `AuthorizationSuccessHandler`.

## Screenshots (Optional)
### User logs in while suspended
<img width="620" alt="image" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/61306390/0947591d-0dc8-4639-87ac-68aa05fe649a">

Note: both changes caused an unaesthetic `Whitelabel Error Page` no matter what configuration of response errors I did; thus perhaps a future issue would be creating an explicit mapping for `/error` to handle these random error pages.

### User is suspended while logged in
<img width="1363" alt="image" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/61306390/9a293b46-e505-49e9-8f83-8c8f4bdf08f0">

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Go to my dokku deployment: https://proj-happycows-jm.dokku-08.cs.ucsb.edu/
2. Log in on Oauth
3. On a new browser, open the https://proj-happycows-jm.dokku-08.cs.ucsb.edu/swagger-ui/index.html
5. Suspend your userId
6. Navigate back to original browser; you should have been suspended
7. On another browser, log in through another admin account and restore the user
8. The suspended user should be able to log in again

## Tests
<!--Add any additional tests or required tests-->
- [X] Backend Unit tests (`mvn test`) pass
- [X] Backend Test coverage (`mvn test jacoco:report`) 100%
- [X] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues
Closes #22 
