### PR TITLE
va - Created Admin Announcements page and tests

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,6 +19,7 @@ import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 import AdminViewPlayPage from "main/pages/AdminViewPlayPage";
+import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
 
 function App() {
     const { data: currentUser } = useCurrentUser();
@@ -47,6 +48,10 @@ function App() {
             <Route
                 path="/admin/play/:commonsId/user/:userId"
                 element={<AdminViewPlayPage />}
+            />
+            <Route
+                path="/admin/announcements/:commonsId"
+                element={<AdminAnnouncementsPage />}
             />
         </>
     ) : null;

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -117,6 +117,7 @@ export default function CommonsTable({ commons, currentUser }) {
         ButtonColumn("Delete", "danger", deleteCallback, testid),
         ButtonColumn("Leaderboard", "secondary", leaderboardCallback, testid),
         HrefButtonColumn("Stats CSV", "success", `/api/commonstats/download?commonsId=`, testid),
+        HrefButtonColumn("Announcements", "info", `/admin/announcements/`, testid)
     ];
 
     const columnsToDisplay = hasRole(currentUser,"ROLE_ADMIN") ? columnsIfAdmin : columns;

--- a/frontend/src/main/pages/AdminAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.js
@@ -1,0 +1,56 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Row, Col } from "react-bootstrap";
+import { useParams } from "react-router-dom";
+import AnnouncementTable from "main/components/Announcement/AnnouncementTable";
+import { useCurrentUser } from "main/utils/currentUser";
+import { useBackend } from "main/utils/useBackend";
+
+export default function AdminAnnouncementsPage() {
+    const { commonsId } = useParams();
+    const { data: currentUser } = useCurrentUser();
+
+    // Stryker disable all
+    const { data: commonsPlus } = useBackend(
+        [`/api/commons/plus?id=${commonsId}`],
+        {
+            method: "GET",
+            url: "/api/commons/plus",
+            params: {
+                id: commonsId,
+            },
+        }
+    );
+    // Stryker restore all
+
+    // Stryker disable  all 
+    const { data: announcements, error: _error, status: _status } =
+    useBackend(
+        [`/api/announcements/getbycommonsid?commonsId=${commonsId}`],
+        { 
+            method: "GET",
+            url: `/api/announcements/`,
+            params: {
+                commonsId: commonsId
+            }
+        },
+        []
+    );
+    // Stryker restore  all 
+
+    const commonsName = commonsPlus?.commons.name;
+
+    return (
+        <BasicLayout>
+        <div className="pt-2">
+          <Row  className="pt-5">
+            <Col>
+              <h2>Announcements for Commons: {commonsName}</h2>
+            </Col>
+          </Row>
+          <AnnouncementTable announcements={announcements} currentUser={currentUser} />
+        </div>
+      </BasicLayout>
+    );
+
+};

--- a/frontend/src/main/pages/AdminAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.js
@@ -2,13 +2,10 @@ import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { Row, Col } from "react-bootstrap";
 import { useParams } from "react-router-dom";
-import AnnouncementTable from "main/components/Announcement/AnnouncementTable";
-import { useCurrentUser } from "main/utils/currentUser";
 import { useBackend } from "main/utils/useBackend";
 
 export default function AdminAnnouncementsPage() {
     const { commonsId } = useParams();
-    const { data: currentUser } = useCurrentUser();
 
     // Stryker disable all
     const { data: commonsPlus } = useBackend(
@@ -23,21 +20,6 @@ export default function AdminAnnouncementsPage() {
     );
     // Stryker restore all
 
-    // Stryker disable  all 
-    const { data: announcements, error: _error, status: _status } =
-    useBackend(
-        [`/api/announcements/getbycommonsid?commonsId=${commonsId}`],
-        { 
-            method: "GET",
-            url: `/api/announcements/`,
-            params: {
-                commonsId: commonsId
-            }
-        },
-        []
-    );
-    // Stryker restore  all 
-
     const commonsName = commonsPlus?.commons.name;
 
     return (
@@ -48,7 +30,6 @@ export default function AdminAnnouncementsPage() {
               <h2>Announcements for Commons: {commonsName}</h2>
             </Col>
           </Row>
-          <AnnouncementTable announcements={announcements} currentUser={currentUser} />
         </div>
       </BasicLayout>
     );

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -105,7 +105,7 @@ describe("UserTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`)).toHaveClass("btn-danger");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Leaderboard-button`)).toHaveClass("btn-secondary");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Stats CSV-button`)).toHaveClass("btn-success");
-
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Announcements-button`)).toHaveClass("btn-info");
   });
 
 });

--- a/frontend/src/tests/pages/AdminAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminAnnouncementsPage.test.js
@@ -6,13 +6,17 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
+import AdminListCommonsPage from "main/pages/AdminListCommonPage";
+import commonsPlusFixtures from "fixtures/commonsPlusFixtures"
+
+const mockedNavigate = jest.fn();
 
 jest.mock("react-router-dom", () => ({
     ...jest.requireActual("react-router-dom"),
     useParams: () => ({
-        userId: 1,
         commonsId: 1,
     }),
+    useNavigate: () => mockedNavigate
 }));
 
 describe("AdminAnnouncementsPage tests", () => {
@@ -59,6 +63,25 @@ describe("AdminAnnouncementsPage tests", () => {
         );
 
         expect(await screen.findByText("Announcements for Commons: Sample Commons")).toBeInTheDocument();
+
+    });
+
+    test("correct href for announcements button as an admin", async () => {
+        const testId = "CommonsTable";
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsPlusFixtures.threeCommonsPlus);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminListCommonsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-commons.id`)).toHaveTextContent("1");
+      
+        const announcementsButton = screen.getByTestId(`${testId}-cell-row-0-col-Announcements-button`);
+        expect(announcementsButton).toHaveAttribute("href", "/admin/announcements/1");
 
     });
 });

--- a/frontend/src/tests/pages/AdminAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminAnnouncementsPage.test.js
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
+
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useParams: () => ({
+        userId: 1,
+        commonsId: 1,
+    }),
+}));
+
+describe("AdminAnnouncementsPage tests", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+    const queryClient = new QueryClient();
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    test("renders page without crashing", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminAnnouncementsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+    });
+
+    test("renders announcements with correct commons name", async () => {
+        axiosMock
+            .onGet("/api/currentUser")
+            .reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
+            commons: {
+                id: 1,
+                name: "Sample Commons",
+            },
+            totalPlayers: 5,
+            totalCows: 5,
+        });
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminAnnouncementsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText("Announcements for Commons: Sample Commons")).toBeInTheDocument();
+
+    });
+});


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I added an Announcements page for the Admin. To view the Announcements Page for a specific common, navigate to Admin -> List Commons and the last column has Announcement buttons for each commons created. Clicking on it will take the admin to the Announcements Page that displays the name of the commons for which the announcements are for.

## Screenshots (Optional)
<img width="1352" alt="image" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/91294025/eeeba174-ba40-4972-b05e-6605163ae236">
<img width="1357" alt="image" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/91294025/e0315e85-78c6-4989-bb8f-f6a9ecbaed25">

## Feedback Request (Optional)
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->
Please give suggestions on the following:
- The formatting of page I added

## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- This is the beginning/part of Frontend Create, read operations for announcements (and optionally Edit, Delete) as an admin.

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Go to this page: https://proj-happycows-va.dokku-08.cs.ucsb.edu/
3. Click on Admin -> List Commons and then horizontally scroll to the Announcement Button for the commons you wish to look at and verify that the name matches the commons you clicked on.

## Tests
<!--Add any additional tests or required tests-->
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #28 
