### PR TITLE
NM-Better Profits Table Display with Pagination

### DIFF
--- a/frontend/src/fixtures/pagedProfitsFixtures.js
+++ b/frontend/src/fixtures/pagedProfitsFixtures.js
@@ -1,0 +1,191 @@
+const pagedProfitsFixtures = {
+    emptyPage: {
+        "content": [],
+        "pageable": {
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "offset": 0,
+            "pageNumber": 0,
+            "pageSize": 5,
+            "paged": true,
+            "unpaged": false
+        },
+        "totalPages": 0,
+        "totalElements": 0,
+        "last": true,
+        "size": 5,
+        "number": 0,
+        "sort": {
+            "empty": false,
+            "unsorted": false,
+            "sorted": true
+        },
+        "numberOfElements": 0,
+        "first": true,
+        "empty": true
+    },
+    onePage:
+    {
+        "content": [
+            {
+                "amount": 110,
+                "timestamp": "2024-06-16T20:55:00.01234",
+                "numCows": 5,
+                "avgCowHealth": 100,
+
+            },
+            {
+                "amount": 105,
+                "timestamp": "2024-07-16T20:55:00.01234",
+                "numCows": 4,
+                "avgCowHealth": 94,
+            },
+
+        ],
+        "pageable": {
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "offset": 0,
+            "pageNumber": 0,
+            "pageSize": 5,
+            "paged": true,
+            "unpaged": false
+        },
+        "totalPages": 1,
+        "totalElements": 2,
+        "last": true,
+        "size": 5,
+        "number": 0,
+        "sort": {
+            "empty": false,
+            "unsorted": false,
+            "sorted": true
+        },
+        "numberOfElements": 2,
+        "first": true,
+        "empty": false
+    },
+    twoPages: [
+        {
+            "content": [
+                {
+                    "amount": 20,
+                    "timestamp": "2024-10-20T11:45:00.01234",
+                    "numCows": 4,
+                    "avgCowHealth": 90,
+                },
+                {
+                    "amount": 19,
+                    "timestamp": "2025-10-12T11:45:00.01234",
+                    "numCows": 9,
+                    "avgCowHealth": 91,
+                },
+                {
+                    "amount": 18,
+                    "timestamp": "2024-10-20T11:45:00.01234",
+                    "numCows": 7,
+                    "avgCowHealth": 50,
+                },
+                {
+                    "amount": 18,
+                    "timestamp": "2023-03-03T11:45:00.01234",
+                    "numCows": 8,
+                    "avgCowHealth": 34,
+                },
+                {
+                    "amount": 120,
+                    "timestamp": "2022-05-16T11:45:00.01234",
+                    "numCows": 6,
+                    "avgCowHealth": 78,
+                }
+            ],
+            "pageable": {
+                "sort": {
+                    "empty": false,
+                    "unsorted": false,
+                    "sorted": true
+                },
+                "offset": 0,
+                "pageNumber": 0,
+                "pageSize": 5,
+                "paged": true,
+                "unpaged": false
+            },
+            "totalPages": 2,
+            "totalElements": 9,
+            "last": false,
+            "size": 5,
+            "number": 0,
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "numberOfElements": 5,
+            "first": true,
+            "empty": false
+        },
+        {
+            "content": [
+                {
+                    "amount": 6,
+                    "timestamp": "2022-03-10T11:45:00.01234",
+                    "numCows": 9,
+                    "avgCowHealth": 60,
+                },
+                {
+                    "amount": 90,
+                    "timestamp": "2020-11-03T11:45:00.01234",
+                    "numCows": 9,
+                    "avgCowHealth": 60,
+                },
+                {
+                    "amount": 10,
+                    "timestamp": "2019-03-17T11:45:00.01234",
+                    "numCows": 10,
+                    "avgCowHealth": 81,
+                },
+                {
+                    "amount": 15,
+                    "timestamp": "2003-04-19T11:45:00.01234",
+                    "numCows": 20,
+                    "avgCowHealth": 98,
+                }
+            ],
+            "pageable": {
+                "sort": {
+                    "empty": false,
+                    "unsorted": false,
+                    "sorted": true
+                },
+                "offset": 5,
+                "pageNumber": 1,
+                "pageSize": 5,
+                "paged": true,
+                "unpaged": false
+            },
+            "totalPages": 2,
+            "totalElements": 9,
+            "last": true,
+            "size": 5,
+            "number": 1,
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "numberOfElements": 4,
+            "first": false,
+            "empty": false
+        }
+    ]
+
+};
+
+export default pagedProfitsFixtures;

--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -1,0 +1,104 @@
+import React from "react";
+import OurTable from "main/components/OurTable";
+import { Button } from "react-bootstrap";
+import { useBackend } from "main/utils/useBackend";
+import { useParams } from "react-router-dom";
+import { timestampToDate } from "main/utils/dateUtils";
+
+
+const PagedProfitsTable = () => {
+
+    const testId = "PagedProfitsTable";
+    const refreshJobsIntervalMilliseconds = 5000;
+
+    const [selectedPage, setSelectedPage] = React.useState(0);
+
+    const PROFIT_PAGE_SIZE = 5;
+    const { commonsId } = useParams();
+
+    // Stryker disable all
+    const {
+        data: page
+    } = useBackend(
+        ["/api/profits/paged/commonsid"],
+        {
+            method: "GET",
+            url: "/api/profits/paged/commonsid", 
+            params: {
+                commonsId: commonsId,
+                pageNumber: selectedPage,
+                pageSize: PROFIT_PAGE_SIZE,
+            }
+        },
+        {content: [], totalPages: 0},
+        { refetchInterval: refreshJobsIntervalMilliseconds }
+    );
+    // Stryker restore  all
+
+    const testid = "PagedProfitsTable";
+
+    const previousPageCallback = () => {
+        return () => {
+            setSelectedPage(selectedPage - 1);
+        }
+    }
+
+    const nextPageCallback = () => {
+        return () => {
+            setSelectedPage(selectedPage + 1);
+        }
+    }
+
+    const columns = 
+        [
+            {
+                Header: "Profit",
+                accessor: "amount",
+                Cell: ({value}) => `$${value.toFixed(2)}`,
+            },
+            {
+                Header: "Date",
+                accessor: "timestamp",
+                Cell: ({ value }) => timestampToDate(value),
+            },
+            {
+                Header: "Health",
+                accessor: "avgCowHealth",
+                Cell: ({value}) => `${value.toFixed(2) + '%'}`
+            },
+            {
+                Header: "Cows",
+                accessor: "numCows",
+            },
+        ];
+
+
+    const sortees = React.useMemo(
+        () => [
+            {
+                id: "timestamp",
+                desc: true
+            }
+        ],
+        // Stryker disable next-line all
+        []
+    );
+
+
+    return (
+        <>
+            <p>Page: {selectedPage + 1}</p>
+            <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
+            <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
+            < OurTable
+                data={page.content}
+                columns={columns}
+                testid={testid}
+                initialState={{ sortBy: sortees }}
+
+            />
+        </>
+    );
+}; 
+
+export default PagedProfitsTable;

--- a/frontend/src/main/components/Commons/Profits.js
+++ b/frontend/src/main/components/Commons/Profits.js
@@ -1,20 +1,11 @@
 import React from "react";
 import { Card } from "react-bootstrap";
-import ProfitsTable from "main/components/Commons/ProfitsTable";
-
-import { timestampToDate } from "main/utils/dateUtils";
+import PagedProfitsTable from "main/components/Commons/PagedProfitsTable";
 
 
-const Profits = ({ profits }) => {
-    const profitsForTable =
-        profits ?
-        profits.map(profit => ({
-            date: timestampToDate(profit.timestamp),
-            ...profit
-        })) : 
-        // Stryker disable next-line ArrayDeclaration : no need to test what happens if [] is replaced with ["Stryker was here"]
-        [];
-        profitsForTable.reverse();
+
+
+const Profits = () =>{
     return (
         <Card>
             <Card.Header as="h5">
@@ -25,7 +16,7 @@ const Profits = ({ profits }) => {
                 <Card.Title>
                     You will earn profits from milking your cows everyday at 4am.
                 </Card.Title>
-                <ProfitsTable profits={profitsForTable} />
+                <PagedProfitsTable/>
             </Card.Body>
         </Card>
     );

--- a/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
@@ -1,0 +1,200 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import PagedProfitsTable from "main/components/Commons/PagedProfitsTable";
+import pagedProfitsFixtures from "fixtures/pagedProfitsFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("PagedProfitsTable tests", () => {
+
+  const queryClient = new QueryClient();
+
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "PagedProfitsTable";
+
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+  });
+
+
+
+  test("renders correct content", async () => {
+
+    // arrange
+    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.onePage);
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    // assert
+    const expectedHeaders = ['Profit', 'Date', 'Health', 'Cows'];
+    const expectedFields = ['amount', 'timestamp', 'avgCowHealth', 'numCows'];
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
+    expect(axiosMock.history.get[0].params).toEqual({commonsId: undefined, pageNumber: 0, pageSize: 5 });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-amount`)).toHaveTextContent(
+      "110");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-timestamp`)
+    ).toHaveTextContent("2024-06-16");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-avgCowHealth`)
+    ).toHaveTextContent("100.00%");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-numCows`)
+    ).toHaveTextContent("5");
+
+
+    expect(screen.getByTestId(`${testId}-header-timestamp-sort-carets`)).toHaveTextContent("🔽");
+
+
+    const nextButton = screen.getByTestId(`${testId}-next-button`);
+    expect(nextButton).toBeInTheDocument();
+    expect(nextButton).toBeDisabled();
+
+    const previousButton = screen.getByTestId(`${testId}-previous-button`);
+    expect(previousButton).toBeInTheDocument();
+    expect(previousButton).toBeDisabled();
+  });
+
+   test("buttons are disabled where there are zero pages", async () => {
+
+    // arrange
+
+    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.emptyPage);
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+
+    expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
+    expect(axiosMock.history.get[0].params).toEqual({ commonsId:undefined, pageNumber: 0, pageSize: 5 });
+
+    const nextButton = screen.getByTestId(`${testId}-next-button`);
+    expect(nextButton).toBeInTheDocument();
+    expect(nextButton).toBeDisabled();
+
+    const previousButton = screen.getByTestId(`${testId}-previous-button`);
+    expect(previousButton).toBeInTheDocument();
+    expect(previousButton).toBeDisabled();
+  }); 
+
+
+
+
+
+  test("renders correct content with multiple pages", async () => {
+    // arrange
+
+    axiosMock.onGet("/api/profits/paged/commonsid"   ,{ params: {commonsId: undefined, pageNumber: 0, pageSize: 5 } }   ).reply(200, pagedProfitsFixtures.twoPages[0]);
+    axiosMock.onGet("/api/profits/paged/commonsid" ,{ params: {commonsId: undefined, pageNumber: 1, pageSize: 5 } }     ).reply(200, pagedProfitsFixtures.twoPages[1]);
+
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    // assert
+    const expectedHeaders = ['Profit', 'Date', 'Health', 'Cows'];
+    const expectedFields = ['amount', 'timestamp', 'avgCowHealth', 'numCows'];
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+
+
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
+    expect(axiosMock.history.get[0].params).toEqual({ commonsId: undefined, pageNumber: 0, pageSize: 5 });
+
+
+
+    const nextButton = screen.getByTestId(`${testId}-next-button`);
+    expect(nextButton).toBeInTheDocument();
+
+    const previousButton = screen.getByTestId(`${testId}-previous-button`);
+    expect(previousButton).toBeInTheDocument();
+
+    expect(previousButton).toBeDisabled();
+    expect(nextButton).toBeEnabled();
+
+    expect(screen.getByText(`Page: 1`)).toBeInTheDocument();
+
+    expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-amount`)
+      ).toHaveTextContent("20");
+
+    fireEvent.click(nextButton);
+
+
+    await waitFor(() => {expect(screen.getByText(`Page: 2`)).toBeInTheDocument();});
+    expect(previousButton).toBeEnabled();
+    expect(nextButton).toBeDisabled();
+
+
+    fireEvent.click(previousButton);
+    await waitFor(() => { expect(screen.getByText(`Page: 1`)).toBeInTheDocument();});
+    expect(previousButton).toBeDisabled();
+    expect(nextButton).toBeEnabled(); 
+
+     expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-amount`)
+      ).toHaveTextContent("20"); 
+
+
+
+  });
+
+
+    });

--- a/frontend/src/tests/components/Commons/Profits.test.js
+++ b/frontend/src/tests/components/Commons/Profits.test.js
@@ -1,44 +1,23 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import Profits from "main/components/Commons/Profits"; 
 import userCommonsFixtures from "fixtures/userCommonsFixtures"; 
-import profitsFixtures from "fixtures/profitsFixtures";
+
+import { QueryClient, QueryClientProvider } from "react-query";
 
 describe("Profits tests", () => {
-    test("renders properly for empty profits array", () => {
+    
+    test("renders properly when profits is not given", async () => {
+        const queryClient = new QueryClient();
         render(
-            <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} profits={[]} />
-        );
-    });
-
-    test("renders properly when profits is not defined", async () => {
-        render(
-            <Profits userCommons={userCommonsFixtures.oneUserCommons[0]}  />
+        <QueryClientProvider client={queryClient}>
+                <Profits userCommons={userCommonsFixtures.oneUserCommons[0]}  />
+        </QueryClientProvider>
+            
         );
         await waitFor(()=>{
-            expect(screen.getByTestId("ProfitsTable-header-Profit") ).toBeInTheDocument();
+            expect(screen.getByTestId("PagedProfitsTable-header-amount") ).toBeInTheDocument();
         });
     });
 
-    test("renders properly when profits is non-empty", async () => {
-        render(
-            <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} profits={profitsFixtures.threeProfits} />
-        );
-           
-        expect(await screen.findByTestId("ProfitsTable-cell-row-0-col-Profit")).toBeInTheDocument();
-        expect(screen.getByTestId("ProfitsTable-cell-row-0-col-Profit")).toHaveTextContent(/52.80/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-1-col-Profit")).toHaveTextContent(/54.60/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-2-col-Profit")).toHaveTextContent(/58.20/);
-
-        expect(screen.getByTestId("ProfitsTable-cell-row-0-col-date")).toHaveTextContent(/2023-05-17/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-1-col-date")).toHaveTextContent(/2023-05-16/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-2-col-date")).toHaveTextContent(/2023-05-15/);
-
-        expect(screen.getByTestId("ProfitsTable-cell-row-0-col-Health")).toHaveTextContent(/88%/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-1-col-Health")).toHaveTextContent(/91%/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-2-col-Health")).toHaveTextContent(/97%/);
-
-        expect(screen.getByTestId("ProfitsTable-cell-row-0-col-numCows")).toHaveTextContent(/6/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-1-col-numCows")).toHaveTextContent(/6/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-2-col-numCows")).toHaveTextContent(/6/);
-    });
+    
 });


### PR DESCRIPTION
## Overview
In this PR, I have updated the Profits Table on the play page so it looks similar to the Jobs Table under the Admin "Manage Jobs" section. In this update, the user can use the Previous and the Next buttons to access old profits. 

## Screenshots (Optional)
![Screenshot 2024-05-28 090707](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/97640752/444bdc73-a3a0-43b0-94ce-0a6a776c5f83)



dokku deployment:  https://proj-happycows-nm.dokku-08.cs.ucsb.edu
## Tests
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
closes #5 