### PR TITLE
rk- fixed BUG: Disallow ability to navigate to unjoined commons

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -58,27 +58,33 @@ export default function PlayPage() {
     );
     // Stryker restore all
 
-    // MY STUFF IS HERE 
+
+
+
+    // MY STUFF IS HERE ---------------------------------------------------------------------------------------------------------------------------------
+
     //const commonsPlusExists = !!commonsPlus; // check if it exists.. TYIS ONE IS WRONG 
     const commonsPlusExists = !(typeof commonsPlus == 'undefined'); // need to check for undefined (getting error in console) YEASS IT WORLKED
 
-    let commonsforuser; // does this have to be a const ?
+    let commonsforuser = [];
     let matched; 
+
+    // function checkId(com) { // is this allowed... checking is id matches
+    //     return com.id === commonsPlus.commons.id;
+    // }
 
     if (commonsPlusExists) { // only IF the commons exists, get this info 
         commonsforuser = currentUser.root.user.commons;
-        matched = commonsforuser.some(checkId);
+        matched = commonsforuser.some(com => com.id === commonsPlus?.commons?.id);
     }
-
-    function checkId(com) { // is this allowed... checking is id matches
-        return com.id === commonsPlus.commons.id;
-    }
-
+    
     // so then, I can use these for condition checking inside the play page itself 
     const allowed = commonsPlusExists && matched;
     const notallowed = commonsPlusExists && !matched;
 
+    //-------------------------------------------------------------------------------------------------------------------------------------------------
 
+    
     // Stryker disable all
     const { data: userCommonsProfits } = useBackend(
         [`/api/profits/all/commonsid?commonsId=${commonsId}`],

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -22,6 +22,8 @@ export default function PlayPage() {
     const [message, setMessage] = useState();
     const [numCows, setNumCows] = useState(1);
 
+    
+
     const openModal = () => {
         setIsModalOpen(true);
     };
@@ -55,6 +57,27 @@ export default function PlayPage() {
         }
     );
     // Stryker restore all
+
+    // MY STUFF IS HERE 
+    //const commonsPlusExists = !!commonsPlus; // check if it exists.. TYIS ONE IS WRONG 
+    const commonsPlusExists = !(typeof commonsPlus == 'undefined'); // need to check for undefined (getting error in console) YEASS IT WORLKED
+
+    let commonsforuser; // does this have to be a const ?
+    let matched; 
+
+    if (commonsPlusExists) { // only IF the commons exists, get this info 
+        commonsforuser = currentUser.root.user.commons;
+        matched = commonsforuser.some(checkId);
+    }
+
+    function checkId(com) { // is this allowed... checking is id matches
+        return com.id === commonsPlus.commons.id;
+    }
+
+    // so then, I can use these for condition checking inside the play page itself 
+    const allowed = commonsPlusExists && matched;
+    const notallowed = commonsPlusExists && !matched;
+
 
     // Stryker disable all
     const { data: userCommonsProfits } = useBackend(
@@ -160,7 +183,8 @@ export default function PlayPage() {
         >
             <BasicLayout>
                 <Container>
-                    {!!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    {allowed && !!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    {notallowed && <h1>You have yet to join this commons!</h1>}
                     {!!commonsPlus && (
                         <CommonsOverview
                             commonsPlus={commonsPlus}

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -62,7 +62,7 @@ export default function PlayPage() {
     let commonsforuser;
     let matched; 
 
-    if (commonsPlusExists) { // only IF the commons exists, get this info 
+    if (commonsPlusExists) { 
         commonsforuser = currentUser.root.user.commons;
         matched = commonsforuser.some(com => com.id === commonsPlus.commons.id);
     }

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -58,33 +58,18 @@ export default function PlayPage() {
     );
     // Stryker restore all
 
-
-
-
-    // MY STUFF IS HERE ---------------------------------------------------------------------------------------------------------------------------------
-
-    //const commonsPlusExists = !!commonsPlus; // check if it exists.. TYIS ONE IS WRONG 
-    const commonsPlusExists = !(typeof commonsPlus == 'undefined'); // need to check for undefined (getting error in console) YEASS IT WORLKED
-
-    let commonsforuser = [];
+    const commonsPlusExists = !(typeof commonsPlus == 'undefined'); 
+    let commonsforuser;
     let matched; 
-
-    // function checkId(com) { // is this allowed... checking is id matches
-    //     return com.id === commonsPlus.commons.id;
-    // }
 
     if (commonsPlusExists) { // only IF the commons exists, get this info 
         commonsforuser = currentUser.root.user.commons;
-        matched = commonsforuser.some(com => com.id === commonsPlus?.commons?.id);
+        matched = commonsforuser.some(com => com.id === commonsPlus.commons.id);
     }
-    
-    // so then, I can use these for condition checking inside the play page itself 
+
     const allowed = commonsPlusExists && matched;
     const notallowed = commonsPlusExists && !matched;
 
-    //-------------------------------------------------------------------------------------------------------------------------------------------------
-
-    
     // Stryker disable all
     const { data: userCommonsProfits } = useBackend(
         [`/api/profits/all/commonsid?commonsId=${commonsId}`],

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -39,7 +39,7 @@ describe("CommonsOverview tests", () => {
     });
 
     test("Redirects to the LeaderboardPage for an admin when you click visit", async () => {
-        apiCurrentUserFixtures.adminUser.user.commons = commonsFixtures.oneCommons[0];
+        apiCurrentUserFixtures.adminUser.user.commons[0] = commonsFixtures.oneCommons;
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
         axiosMock.onGet("/api/commons/plus", {params: {id:1}}).reply(200, commonsPlusFixtures.oneCommonsPlus[0]);
         axiosMock.onGet("/api/leaderboard/all").reply(200, leaderboardFixtures.threeUserCommonsLB);

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -344,7 +344,6 @@ describe("PlayPage tests", () => {
         });
     })
 
-
     test("User that has not joined any commons is trying to access an unjoined common", async () => {
 
         axiosMock.reset();
@@ -393,12 +392,11 @@ describe("PlayPage tests", () => {
         expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
     })
 
-
     test("User that has joined one commons is trying to access an unjoined common", async () => {
 
         axiosMock.reset();
         axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+        axiosMock.onGet("/api/currentUser").reply(200, {
                 user: {
                     id : 1,
                     email: "pconrad.cis@gmail.com",
@@ -448,7 +446,7 @@ describe("PlayPage tests", () => {
         axiosMock.reset();
         axiosMock.resetHistory();
 
-        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+        axiosMock.onGet("/api/currentUser").reply(200, { 
                 user: {
                     id : 1,
                     email: "pconrad.cis@gmail.com",
@@ -500,7 +498,7 @@ describe("PlayPage tests", () => {
         axiosMock.reset();
         axiosMock.resetHistory();
 
-        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+        axiosMock.onGet("/api/currentUser").reply(200, { 
                 user: {
                     id : 1,
                     email: "pconrad.cis@gmail.com",

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -343,4 +343,143 @@ describe("PlayPage tests", () => {
             expect(screen.getByTestId("playpage-chat-toggle")).toBeInTheDocument();
         });
     })
+
+
+
+    
+
+    test("User that has not joined any commons is trying to access an unjoined common", async () => {
+
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+                user: {
+                    id : 1,
+                    email: "pconrad.cis@gmail.com",
+                    googleSub: "102656447703889917227",
+                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+                    fullName : "Phil Conrad",
+                    givenName : "Phil",
+                    familyName : "Conrad",
+                    emailVerified : true,
+                    locale: "en",
+                    hostedDomain: null,
+                    admin : false,
+                    commons : [
+                        // {
+                        //     id : 1,
+                        //     name : "Commons1",
+                        // }
+                    ]
+                }
+            }
+        );
+
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();    
+        });
+        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
+    })
+
+
+    test("User that has joined one commons is trying to access an unjoined common", async () => {
+
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+                user: {
+                    id : 1,
+                    email: "pconrad.cis@gmail.com",
+                    googleSub: "102656447703889917227",
+                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+                    fullName : "Phil Conrad",
+                    givenName : "Phil",
+                    familyName : "Conrad",
+                    emailVerified : true,
+                    locale: "en",
+                    hostedDomain: null,
+                    admin : false,
+                    commons : [
+                        {
+                            id : 4,
+                            name : "Commons4",
+                        }
+                    ]
+                }
+            }
+        );
+
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();    
+        });
+        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
+    })
+
+
+    test("User that has joined one commons is trying to access a joined common", async () => {
+
+        axiosMock.reset();
+        axiosMock.resetHistory();
+
+        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+                user: {
+                    id : 1,
+                    email: "pconrad.cis@gmail.com",
+                    googleSub: "102656447703889917227",
+                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+                    fullName : "Phil Conrad",
+                    givenName : "Phil",
+                    familyName : "Conrad",
+                    emailVerified : true,
+                    locale: "en",
+                    hostedDomain: null,
+                    admin : false,
+                    commons : [
+                        {
+                            id : 1,
+                            name : "Commons1",
+                        }
+                    ]
+                }
+            }
+        );
+
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("Announcements")).toBeInTheDocument();
+        });        
+
+        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+    })
+
 });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -361,12 +361,7 @@ describe("PlayPage tests", () => {
                     locale: "en",
                     hostedDomain: null,
                     admin : false,
-                    commons : [
-                        // {
-                        //     id : 1,
-                        //     name : "Commons1",
-                        // }
-                    ]
+                    commons : []
                 },
                 roles: [
                     {

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -345,141 +345,187 @@ describe("PlayPage tests", () => {
     })
 
 
+    test("User that has not joined any commons is trying to access an unjoined common", async () => {
+
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+                user: {
+                    id : 1,
+                    email: "pconrad.cis@gmail.com",
+                    googleSub: "102656447703889917227",
+                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+                    fullName : "Phil Conrad",
+                    givenName : "Phil",
+                    familyName : "Conrad",
+                    emailVerified : true,
+                    locale: "en",
+                    hostedDomain: null,
+                    admin : false,
+                    commons : [
+                        // {
+                        //     id : 1,
+                        //     name : "Commons1",
+                        // }
+                    ]
+                }
+            }
+        );
+
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();    
+        });
+        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
+    })
 
 
+    test("User that has joined one commons is trying to access an unjoined common", async () => {
 
-    // test("User that has not joined any commons is trying to access an unjoined common", async () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+                user: {
+                    id : 1,
+                    email: "pconrad.cis@gmail.com",
+                    googleSub: "102656447703889917227",
+                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+                    fullName : "Phil Conrad",
+                    givenName : "Phil",
+                    familyName : "Conrad",
+                    emailVerified : true,
+                    locale: "en",
+                    hostedDomain: null,
+                    admin : false,
+                    commons : [
+                        {
+                            id : 4,
+                            name : "Commons4",
+                        }
+                    ]
+                }
+            }
+        );
 
-    //     axiosMock.reset();
-    //     axiosMock.resetHistory();
-    //     axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
-    //             user: {
-    //                 id : 1,
-    //                 email: "pconrad.cis@gmail.com",
-    //                 googleSub: "102656447703889917227",
-    //                 pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
-    //                 fullName : "Phil Conrad",
-    //                 givenName : "Phil",
-    //                 familyName : "Conrad",
-    //                 emailVerified : true,
-    //                 locale: "en",
-    //                 hostedDomain: null,
-    //                 admin : false,
-    //                 commons : [
-    //                     // {
-    //                     //     id : 1,
-    //                     //     name : "Commons1",
-    //                     // }
-    //                 ]
-    //             }
-    //         }
-    //     );
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    //     axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
 
-    //     render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <PlayPage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
-
-    //     await waitFor(() => {
-    //         expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();    
-    //     });
-    //     expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
-    // })
-
-
-    // test("User that has joined one commons is trying to access an unjoined common", async () => {
-
-    //     axiosMock.reset();
-    //     axiosMock.resetHistory();
-    //     axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
-    //             user: {
-    //                 id : 1,
-    //                 email: "pconrad.cis@gmail.com",
-    //                 googleSub: "102656447703889917227",
-    //                 pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
-    //                 fullName : "Phil Conrad",
-    //                 givenName : "Phil",
-    //                 familyName : "Conrad",
-    //                 emailVerified : true,
-    //                 locale: "en",
-    //                 hostedDomain: null,
-    //                 admin : false,
-    //                 commons : [
-    //                     {
-    //                         id : 4,
-    //                         name : "Commons4",
-    //                     }
-    //                 ]
-    //             }
-    //         }
-    //     );
-
-    //     axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-
-    //     render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <PlayPage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
-
-    //     await waitFor(() => {
-    //         expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();    
-    //     });
-    //     expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
-    // })
+        await waitFor(() => {
+            expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();    
+        });
+        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
+    })
 
 
-    // test("User that has joined one commons is trying to access a joined common", async () => {
+    test("User that has joined one commons is trying to access a joined common", async () => {
 
-    //     axiosMock.reset();
-    //     axiosMock.resetHistory();
+        axiosMock.reset();
+        axiosMock.resetHistory();
 
-    //     axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
-    //             user: {
-    //                 id : 1,
-    //                 email: "pconrad.cis@gmail.com",
-    //                 googleSub: "102656447703889917227",
-    //                 pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
-    //                 fullName : "Phil Conrad",
-    //                 givenName : "Phil",
-    //                 familyName : "Conrad",
-    //                 emailVerified : true,
-    //                 locale: "en",
-    //                 hostedDomain: null,
-    //                 admin : false,
-    //                 commons : [
-    //                     {
-    //                         id : 1,
-    //                         name : "Commons1",
-    //                     }
-    //                 ]
-    //             }
-    //         }
-    //     );
+        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+                user: {
+                    id : 1,
+                    email: "pconrad.cis@gmail.com",
+                    googleSub: "102656447703889917227",
+                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+                    fullName : "Phil Conrad",
+                    givenName : "Phil",
+                    familyName : "Conrad",
+                    emailVerified : true,
+                    locale: "en",
+                    hostedDomain: null,
+                    admin : false,
+                    commons : [
+                        {
+                            id : 1,
+                            name : "Commons1",
+                        }
+                    ]
+                }
+            }
+        );
 
-    //     axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    //     render(
-    //         <QueryClientProvider client={queryClient}>
-    //             <MemoryRouter>
-    //                 <PlayPage />
-    //             </MemoryRouter>
-    //         </QueryClientProvider>
-    //     );
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
 
-    //     await waitFor(() => {
-    //         expect(screen.getByText("Announcements")).toBeInTheDocument();
-    //     });        
+        await waitFor(() => {
+            expect(screen.getByText("Announcements")).toBeInTheDocument();
+        });        
 
-    //     expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
-    //     expect(screen.getByTestId("commons-card")).toBeInTheDocument();
-    // })
+        expect(screen.queryByText("You have yet to join this commons!")).not.toBeInTheDocument();
+        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+    })
+
+
+    test("User not allowed and hasn't matched any commons should have 'notallowed' true", async () => {
+
+        axiosMock.reset();
+        axiosMock.resetHistory();
+
+        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+                user: {
+                    id : 1,
+                    email: "pconrad.cis@gmail.com",
+                    googleSub: "102656447703889917227",
+                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+                    fullName : "Phil Conrad",
+                    givenName : "Phil",
+                    familyName : "Conrad",
+                    emailVerified : true,
+                    locale: "en",
+                    hostedDomain: null,
+                    admin : false,
+                    commons : [
+                        {
+                            id : 4,
+                            name : "Commons4",
+                        }
+                    ]
+                }
+            }
+        );
+
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+        const commonsPlusExists = false;
+        const matched = false;
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage commonsPlusExists={commonsPlusExists} matched={matched}/>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("Announcements")).toBeInTheDocument();
+        });        
+
+        expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();
+    })
 
 });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -346,140 +346,140 @@ describe("PlayPage tests", () => {
 
 
 
-    
-
-    test("User that has not joined any commons is trying to access an unjoined common", async () => {
-
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
-                user: {
-                    id : 1,
-                    email: "pconrad.cis@gmail.com",
-                    googleSub: "102656447703889917227",
-                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
-                    fullName : "Phil Conrad",
-                    givenName : "Phil",
-                    familyName : "Conrad",
-                    emailVerified : true,
-                    locale: "en",
-                    hostedDomain: null,
-                    admin : false,
-                    commons : [
-                        // {
-                        //     id : 1,
-                        //     name : "Commons1",
-                        // }
-                    ]
-                }
-            }
-        );
-
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PlayPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        await waitFor(() => {
-            expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();    
-        });
-        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
-    })
 
 
-    test("User that has joined one commons is trying to access an unjoined common", async () => {
+    // test("User that has not joined any commons is trying to access an unjoined common", async () => {
 
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
-                user: {
-                    id : 1,
-                    email: "pconrad.cis@gmail.com",
-                    googleSub: "102656447703889917227",
-                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
-                    fullName : "Phil Conrad",
-                    givenName : "Phil",
-                    familyName : "Conrad",
-                    emailVerified : true,
-                    locale: "en",
-                    hostedDomain: null,
-                    admin : false,
-                    commons : [
-                        {
-                            id : 4,
-                            name : "Commons4",
-                        }
-                    ]
-                }
-            }
-        );
+    //     axiosMock.reset();
+    //     axiosMock.resetHistory();
+    //     axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+    //             user: {
+    //                 id : 1,
+    //                 email: "pconrad.cis@gmail.com",
+    //                 googleSub: "102656447703889917227",
+    //                 pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+    //                 fullName : "Phil Conrad",
+    //                 givenName : "Phil",
+    //                 familyName : "Conrad",
+    //                 emailVerified : true,
+    //                 locale: "en",
+    //                 hostedDomain: null,
+    //                 admin : false,
+    //                 commons : [
+    //                     // {
+    //                     //     id : 1,
+    //                     //     name : "Commons1",
+    //                     // }
+    //                 ]
+    //             }
+    //         }
+    //     );
 
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    //     axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PlayPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+    //     render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <PlayPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
 
-        await waitFor(() => {
-            expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();    
-        });
-        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
-    })
+    //     await waitFor(() => {
+    //         expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();    
+    //     });
+    //     expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
+    // })
 
 
-    test("User that has joined one commons is trying to access a joined common", async () => {
+    // test("User that has joined one commons is trying to access an unjoined common", async () => {
 
-        axiosMock.reset();
-        axiosMock.resetHistory();
+    //     axiosMock.reset();
+    //     axiosMock.resetHistory();
+    //     axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+    //             user: {
+    //                 id : 1,
+    //                 email: "pconrad.cis@gmail.com",
+    //                 googleSub: "102656447703889917227",
+    //                 pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+    //                 fullName : "Phil Conrad",
+    //                 givenName : "Phil",
+    //                 familyName : "Conrad",
+    //                 emailVerified : true,
+    //                 locale: "en",
+    //                 hostedDomain: null,
+    //                 admin : false,
+    //                 commons : [
+    //                     {
+    //                         id : 4,
+    //                         name : "Commons4",
+    //                     }
+    //                 ]
+    //             }
+    //         }
+    //     );
 
-        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
-                user: {
-                    id : 1,
-                    email: "pconrad.cis@gmail.com",
-                    googleSub: "102656447703889917227",
-                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
-                    fullName : "Phil Conrad",
-                    givenName : "Phil",
-                    familyName : "Conrad",
-                    emailVerified : true,
-                    locale: "en",
-                    hostedDomain: null,
-                    admin : false,
-                    commons : [
-                        {
-                            id : 1,
-                            name : "Commons1",
-                        }
-                    ]
-                }
-            }
-        );
+    //     axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    //     render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <PlayPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
 
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PlayPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+    //     await waitFor(() => {
+    //         expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();    
+    //     });
+    //     expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
+    // })
 
-        await waitFor(() => {
-            expect(screen.getByText("Announcements")).toBeInTheDocument();
-        });        
 
-        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
-        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
-    })
+    // test("User that has joined one commons is trying to access a joined common", async () => {
+
+    //     axiosMock.reset();
+    //     axiosMock.resetHistory();
+
+    //     axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+    //             user: {
+    //                 id : 1,
+    //                 email: "pconrad.cis@gmail.com",
+    //                 googleSub: "102656447703889917227",
+    //                 pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+    //                 fullName : "Phil Conrad",
+    //                 givenName : "Phil",
+    //                 familyName : "Conrad",
+    //                 emailVerified : true,
+    //                 locale: "en",
+    //                 hostedDomain: null,
+    //                 admin : false,
+    //                 commons : [
+    //                     {
+    //                         id : 1,
+    //                         name : "Commons1",
+    //                     }
+    //                 ]
+    //             }
+    //         }
+    //     );
+
+    //     axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    //     render(
+    //         <QueryClientProvider client={queryClient}>
+    //             <MemoryRouter>
+    //                 <PlayPage />
+    //             </MemoryRouter>
+    //         </QueryClientProvider>
+    //     );
+
+    //     await waitFor(() => {
+    //         expect(screen.getByText("Announcements")).toBeInTheDocument();
+    //     });        
+
+    //     expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+    //     expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+    // })
 
 });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -348,7 +348,7 @@ describe("PlayPage tests", () => {
 
         axiosMock.reset();
         axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, { // the only info i need to get is that of the current user.. but do i need to check if the commons exists?
+        axiosMock.onGet("/api/currentUser").reply(200, { 
                 user: {
                     id : 1,
                     email: "pconrad.cis@gmail.com",

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -368,7 +368,12 @@ describe("PlayPage tests", () => {
                         //     name : "Commons1",
                         // }
                     ]
-                }
+                },
+                roles: [
+                    {
+                        authority: "ROLE_USER"
+                    },
+                ]
             }
         );
 
@@ -412,7 +417,12 @@ describe("PlayPage tests", () => {
                             name : "Commons4",
                         }
                     ]
-                }
+                },
+                roles: [
+                    {
+                        authority: "ROLE_USER"
+                    },
+                ]
             }
         );
 
@@ -457,7 +467,12 @@ describe("PlayPage tests", () => {
                             name : "Commons1",
                         }
                     ]
-                }
+                },
+                roles: [
+                    {
+                        authority: "ROLE_USER"
+                    },
+                ]
             }
         );
 
@@ -474,7 +489,7 @@ describe("PlayPage tests", () => {
         await waitFor(() => {
             expect(screen.getByText("Announcements")).toBeInTheDocument();
         });        
-
+  
         expect(screen.queryByText("You have yet to join this commons!")).not.toBeInTheDocument();
         expect(screen.getByTestId("commons-card")).toBeInTheDocument();
     })
@@ -504,7 +519,12 @@ describe("PlayPage tests", () => {
                             name : "Commons4",
                         }
                     ]
-                }
+                },
+                roles: [
+                    {
+                        authority: "ROLE_USER"
+                    },
+                ]
             }
         );
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I added a functionality to catch when users try to navigate to a commons that they are not a part of. 

## Screenshots
<img width="1512" alt="Screenshot 2024-05-28 at 10 25 34 AM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/92010151/b79c7361-9177-4dc3-8325-e13881ec4957">

## Future Possibilities 
- We could create a whole new page for users to be redirected to if they try to access a commons that they are not a part of. I just changed the header text on the page that they access when doing this. 
- We could also redirect users to a different error page when they try to access a commons that does not exist.

## Validation 
<!--Steps that someone else could take to make sure everything is working-->
- login to happy cows on this deployment: https://proj-happycows-rk.dokku-08.cs.ucsb.edu
- Make a commons and do not join it 
- in the search bar, add /play/commonsID to the end of the url where commonsID is the id of the commons that you created but did not join 
- observe the message: "You have yet to join this commons!"

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #10 
