### PR TITLE
rk - fixed BUG: Disallow ability to navigate to commons not created yet

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -174,9 +174,10 @@ export default function PlayPage() {
         >
             <BasicLayout>
                 <Container> 
-                    {!!commonsPlusExists && <h1>This commons does not exist!</h1>}
-                    {allowed && !!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    {!commonsPlus && <h1>This commons does not exist!</h1>}
                     {notallowed && <h1>You have yet to join this commons!</h1>} 
+                    {allowed && !!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    
                     {!!commonsPlus && (
                         <CommonsOverview
                             commonsPlus={commonsPlus}

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -58,7 +58,7 @@ export default function PlayPage() {
     );
     // Stryker restore all
 
-    const commonsPlusExists = !(typeof commonsPlus == 'undefined'); // does the commons exist?
+    const commonsPlusExists = !(typeof commonsPlus == 'undefined'); 
     let commonsforuser;
     let matched; 
 

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -58,7 +58,7 @@ export default function PlayPage() {
     );
     // Stryker restore all
 
-    const commonsPlusExists = !(typeof commonsPlus == 'undefined'); 
+    const commonsPlusExists = !(typeof commonsPlus == 'undefined'); // does the commons exist?
     let commonsforuser;
     let matched; 
 
@@ -173,9 +173,10 @@ export default function PlayPage() {
             data-testid="playpage-div"
         >
             <BasicLayout>
-                <Container>
+                <Container> 
+                    {!!commonsPlusExists && <h1>This commons does not exist!</h1>}
                     {allowed && !!currentUser && <CommonsPlay currentUser={currentUser} />}
-                    {notallowed && <h1>You have yet to join this commons!</h1>}
+                    {notallowed && <h1>You have yet to join this commons!</h1>} 
                     {!!commonsPlus && (
                         <CommonsOverview
                             commonsPlus={commonsPlus}

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -66,7 +66,7 @@ describe("PlayPage tests", () => {
         axiosMock.onPut("/api/usercommons/buy").reply(200, userCommons);
     });
 
-    test("renders without crashing", () => {
+    test("renders without crashing", async () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -86,6 +86,7 @@ describe("PlayPage tests", () => {
         );
 
         expect(await screen.findByTestId("buy-cow-button")).toBeInTheDocument();
+        expect(screen.queryByText("This commons does not exist!")).not.toBeInTheDocument();
         const buyCowButton = screen.getByTestId("buy-cow-button");
         fireEvent.click(buyCowButton);
 
@@ -532,7 +533,7 @@ describe("PlayPage tests", () => {
                     <PlayPage commonsPlusExists={commonsPlusExists} matched={matched}/> 
                 </MemoryRouter>
             </QueryClientProvider>
-        );
+        ); 
 
         await waitFor(() => {
             expect(screen.getByText("Announcements")).toBeInTheDocument();
@@ -591,54 +592,4 @@ describe("PlayPage tests", () => {
         });        
     })
 
-    
-    test("User not allowed to access a commons that does not exist - test for negation of commonsPlusExists", async () => {
-
-        axiosMock.reset();
-        axiosMock.resetHistory();
-    
-        axiosMock.onGet("/api/currentUser").reply(200, { 
-            user: {
-                id: 1,
-                email: "pconrad.cis@gmail.com",
-                googleSub: "102656447703889917227",
-                pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
-                fullName: "Phil Conrad",
-                givenName: "Phil",
-                familyName: "Conrad",
-                emailVerified: true,
-                locale: "en",
-                hostedDomain: null,
-                admin: false,
-                commons: [
-                    {
-                        id: 5,
-                        name: "hello5",
-                    }
-                ]
-            },
-            roles: [
-                {
-                    authority: "ROLE_USER"
-                }
-            ]
-        });
-    
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-        //axiosMock.onGet("/api/commons/plus").reply(200, undefined);
-        const commonsPlusExists = true;
-    
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PlayPage commonsPlusExists={commonsPlusExists}/>
-                </MemoryRouter>
-            </QueryClientProvider>
-        ); 
-    
-        await waitFor(() => { 
-            expect(screen.queryByText("Announcements")).toBeInTheDocument();
-        });       
-    })
-
-});
+});  

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -529,7 +529,7 @@ describe("PlayPage tests", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <PlayPage commonsPlusExists={commonsPlusExists} matched={matched}/>
+                    <PlayPage commonsPlusExists={commonsPlusExists} matched={matched}/> 
                 </MemoryRouter>
             </QueryClientProvider>
         );
@@ -539,6 +539,106 @@ describe("PlayPage tests", () => {
         });        
 
         expect(screen.getByText("You have yet to join this commons!")).toBeInTheDocument();
+    })
+
+
+    test("User not allowed to access a commons that does not exist", async () => {
+
+        axiosMock.reset();
+        axiosMock.resetHistory();
+
+        axiosMock.onGet("/api/currentUser").reply(200, { 
+                user: {
+                    id : 1,
+                    email: "pconrad.cis@gmail.com",
+                    googleSub: "102656447703889917227",
+                    pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+                    fullName : "Phil Conrad",
+                    givenName : "Phil",
+                    familyName : "Conrad",
+                    emailVerified : true,
+                    locale: "en",
+                    hostedDomain: null,
+                    admin : false,
+                    commons : [
+                        {
+                            id : 4,
+                            name : "Commons4",
+                        }
+                    ]
+                },
+                roles: [
+                    {
+                        authority: "ROLE_USER"
+                    },
+                ]
+            }
+        );
+
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/commons/plus").reply(200, undefined);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage/>
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { 
+            expect(screen.getByText("This commons does not exist!")).toBeInTheDocument();
+        });        
+    })
+
+    
+    test("User not allowed to access a commons that does not exist - test for negation of commonsPlusExists", async () => {
+
+        axiosMock.reset();
+        axiosMock.resetHistory();
+    
+        axiosMock.onGet("/api/currentUser").reply(200, { 
+            user: {
+                id: 1,
+                email: "pconrad.cis@gmail.com",
+                googleSub: "102656447703889917227",
+                pictureUrl: "https://lh3.googleusercontent.com/a-/AOh14GhpDBUt8eCEqiRT45hrFbcimsX_h1ONn0dc3HV8Bp8=s96-c",
+                fullName: "Phil Conrad",
+                givenName: "Phil",
+                familyName: "Conrad",
+                emailVerified: true,
+                locale: "en",
+                hostedDomain: null,
+                admin: false,
+                commons: [
+                    {
+                        id: 5,
+                        name: "hello5",
+                    }
+                ]
+            },
+            roles: [
+                {
+                    authority: "ROLE_USER"
+                }
+            ]
+        });
+    
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        //axiosMock.onGet("/api/commons/plus").reply(200, undefined);
+        const commonsPlusExists = true;
+    
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage commonsPlusExists={commonsPlusExists}/>
+                </MemoryRouter>
+            </QueryClientProvider>
+        ); 
+    
+        await waitFor(() => { 
+            expect(screen.queryByText("Announcements")).toBeInTheDocument();
+        });       
     })
 
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I added a functionality to catch when users try to navigate to a commons that have not been created yet. It is similar to my previous PR on disallowing the ability to navigate to unjoined commons.

## Screenshots 
<img width="919" alt="Screenshot 2024-05-28 at 11 59 55 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/92010151/7d6b6a5a-550c-4689-9f63-c02773f5fde6">

## Feedback Request
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->
Please give suggestions on the following:
- I would appreciate any advice on how to get rid of the pop up error messages

## Future Possibilities 
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- In the future, it might be possible to redirect users to another page instead of simply displaying a text error message 

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
- login to happy cows on this deployment: https://proj-happycows-rk.dokku-08.cs.ucsb.edu/
- in the search bar, add /play/commonsID to the end of the url where commonsID is the id of the commons that you did not create
- observe the message: "This commons does not exist!"

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #33 
