### PR TITLE
rk - fixed the date issue, just had to change timezone

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -70,7 +70,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     
     const testid = "CommonsForm";
     const curr = new Date();
-    const today = curr.toISOString().split('T')[0];
+    const today = curr.toLocaleDateString('en-CA');
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -70,7 +70,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     
     const testid = "CommonsForm";
     const curr = new Date();
-    const today = curr.toLocaleDateString('en-CA');
+    const today = curr.toLocaleDateString('en-CA'); // Canadian english gives YYYY-MM-DD
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -360,7 +360,7 @@ test("the correct parameters are passed to useBackend", async () => {
   test("populates form fields with default values when initialCommons is not provided", async () => {
 
     const curr = new Date();
-    const today = curr.toLocaleDateString('en-CA');
+    const today = curr.toLocaleDateString('en-CA'); // Canadian english gives YYYY-MM-DD
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const defaultValuesData = {

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -288,7 +288,7 @@ describe("CommonsForm tests", () => {
 
   it("renders correctly when an initialCommons is not passed in", async () => {
     const curr = new Date();
-    const today = curr.toLocaleDateString('en-CA');
+    const today = curr.toLocaleDateString('en-CA'); // Canadian english gives YYYY-MM-DD
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -154,7 +154,7 @@ describe("CommonsForm tests", () => {
   it("Check Default Values and correct styles", async () => {
 
     const curr = new Date();
-    const today = curr.toLocaleDateString('en-CA');
+    const today = curr.toLocaleDateString('en-CA'); // Canadian english gives YYYY-MM-DD
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -9,7 +9,7 @@ import healthUpdateStrategyListFixtures from "fixtures/healthUpdateStrategyListF
 
 // Next line uses technique from https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
 import * as useBackendModule from "main/utils/useBackend";
-
+   
 const mockedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
@@ -154,7 +154,7 @@ describe("CommonsForm tests", () => {
   it("Check Default Values and correct styles", async () => {
 
     const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const today = curr.toLocaleDateString('en-CA');
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {
@@ -288,7 +288,7 @@ describe("CommonsForm tests", () => {
 
   it("renders correctly when an initialCommons is not passed in", async () => {
     const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const today = curr.toLocaleDateString('en-CA');
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {
@@ -360,7 +360,7 @@ test("the correct parameters are passed to useBackend", async () => {
   test("populates form fields with default values when initialCommons is not provided", async () => {
 
     const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const today = curr.toLocaleDateString('en-CA');
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const defaultValuesData = {


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I changed default start date when creating a commons to be today's date. I changed the timezone for the starting date to be local to Canada (bc of date formatting).

## Screenshots (Optional)
<img width="1465" alt="Screenshot 2024-05-29 at 11 41 56 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-8/assets/92010151/1947329c-a38d-42d3-8480-2ba4ead058e7">

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
- Go to https://proj-happycows-rk.dokku-08.cs.ucsb.edu
- Create a commons
- Observe that the starting date is always today's date. 


## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #8 
